### PR TITLE
expose logical timestamp information in EventIterator

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -124,6 +124,8 @@ pub enum EventData {
         flags: u8,
         uuid: Uuid,
         coordinate: u64,
+        last_committed: Option<u64>,
+        sequence_number: Option<u64>,
     },
     QueryEvent {
         thread_id: u32,
@@ -344,10 +346,20 @@ impl EventData {
                 cursor.read_exact(&mut uuid_buf)?;
                 let uuid = Uuid::from_bytes(&uuid_buf)?;
                 let offset = cursor.read_u64::<LittleEndian>()?;
+                let (last_committed, sequence_number) = match cursor.read_u8() {
+                    Ok(0x02) => {
+                        let last_committed = cursor.read_u64::<LittleEndian>()?;
+                        let sequence_number = cursor.read_u64::<LittleEndian>()?;
+                        (Some(last_committed), Some(sequence_number))
+                    }
+                    _ => (None, None),
+                };
                 Ok(Some(EventData::GtidLogEvent {
                     flags,
                     uuid,
                     coordinate: offset,
+                    last_committed,
+                    sequence_number,
                 }))
             }
             TypeCode::QueryEvent => {

--- a/src/event.rs
+++ b/src/event.rs
@@ -532,4 +532,8 @@ impl Event {
     pub fn event_length(&self) -> u32 {
         self.event_length
     }
+
+    pub fn offset(&self) -> u64 {
+        self.offset
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,12 @@ impl ToString for Gtid {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct LogicalTimestamp {
+    last_committed: u64,
+    sequence_number: u64,
+}
+
 #[derive(Debug, Serialize)]
 /// A binlog event as returned by [`EventIterator`]. Filters out internal events
 /// like the TableMapEvent and simplifies mapping GTIDs to individual events.
@@ -75,6 +81,7 @@ pub struct BinlogEvent {
     // warning: Y2038 Problem ahead
     pub timestamp: u32,
     pub gtid: Option<Gtid>,
+    pub logical_timestamp: Option<LogicalTimestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -90,6 +97,7 @@ pub struct EventIterator<BR: Read + Seek> {
     events: binlog_file::BinlogEvents<BR>,
     table_map: table_map::TableMap,
     current_gtid: Option<Gtid>,
+    logical_timestamp: Option<LogicalTimestamp>,
 }
 
 impl<BR: Read + Seek> EventIterator<BR> {
@@ -98,6 +106,7 @@ impl<BR: Read + Seek> EventIterator<BR> {
             events: bf.events(start_offset),
             table_map: table_map::TableMap::new(),
             current_gtid: None,
+            logical_timestamp: None,
         }
     }
 }
@@ -114,9 +123,23 @@ impl<BR: Read + Seek> Iterator for EventIterator<BR> {
             match event.inner(Some(&self.table_map)) {
                 Ok(Some(e)) => match e {
                     EventData::GtidLogEvent {
-                        uuid, coordinate, ..
+                        uuid,
+                        coordinate,
+                        last_committed,
+                        sequence_number,
+                        ..
                     } => {
                         self.current_gtid = Some(Gtid(uuid, coordinate));
+                        if let (Some(last_committed), Some(sequence_number)) =
+                            (last_committed, sequence_number)
+                        {
+                            self.logical_timestamp = Some(LogicalTimestamp {
+                                last_committed,
+                                sequence_number,
+                            });
+                        } else {
+                            self.logical_timestamp = None;
+                        }
                     }
                     EventData::TableMapEvent {
                         table_id,
@@ -133,6 +156,7 @@ impl<BR: Read + Seek> Iterator for EventIterator<BR> {
                             type_code: event.type_code(),
                             timestamp: event.timestamp(),
                             gtid: self.current_gtid,
+                            logical_timestamp: self.logical_timestamp,
                             table_name: None,
                             schema_name: None,
                             rows: Vec::new(),
@@ -147,6 +171,7 @@ impl<BR: Read + Seek> Iterator for EventIterator<BR> {
                             type_code: event.type_code(),
                             timestamp: event.timestamp(),
                             gtid: self.current_gtid,
+                            logical_timestamp: self.logical_timestamp,
                             table_name: maybe_table.as_ref().map(|a| a.table_name.to_owned()),
                             schema_name: maybe_table.as_ref().map(|a| a.schema_name.to_owned()),
                             rows,


### PR DESCRIPTION
This exposes the logical_clock dependency information in the binlogs, present in 5.7 or later. When run against 5.6 binlogs, these fields are always None.

The `last_committed` field contains the binlog-relative LSN of the most recent parent transaction; the `sequence_number` field is the current transactions binlog-relative LSN. These are used for extracting concurrency in LOGICAL_CLOCK mode with multi-threaded replication.

There are a bunch more fields in 8.0, but we don't expose them because I don't have an 8.0 server to test with.