### PR TITLE
fix: comply with rust 2021 rules about panic macros

### DIFF
--- a/src/packet_helpers.rs
+++ b/src/packet_helpers.rs
@@ -86,7 +86,7 @@ pub(crate) fn read_var_byte_length_prefixed_bytes<R: Read>(
         }
         4 => r.read_u32::<LittleEndian>()? as usize,
         8 => r.read_u64::<LittleEndian>()? as usize,
-        l => unreachable!(format!("got unexpected length {0:?}", l)),
+        l => unreachable!("got unexpected length {0:?}", l),
     };
     read_nbytes(r, len)
 }


### PR DESCRIPTION
Small change to get rust-mysql-binlog in compliance with rust 2021 rules about panics. `unreachable!` already takes format strings, so no need to call `format!`, and rust 2021 only allows string literals in `panic!` macros like `unreachable!`